### PR TITLE
Avoid creating flush ByteBuf/Segment when not necessary.

### DIFF
--- a/kcp-netty/src/main/java/io/jpower/kcp/netty/Kcp.java
+++ b/kcp-netty/src/main/java/io/jpower/kcp/netty/Kcp.java
@@ -1359,7 +1359,10 @@ public class Kcp {
         } else {
             tsFlush = this.current + interval;
         }
-        flush();
+
+        if(checkFlushRequired()) {
+            flush();
+        }
     }
 
     /**
@@ -1425,6 +1428,65 @@ public class Kcp {
         if (sndQueue.size() > 0) {
             return true;
         }
+        return false;
+    }
+
+    /**
+     * Checks if flush should be called this update.
+     * @return boolean
+     */
+    private boolean checkFlushRequired() {
+        if (ackcount > 0) {
+            return true;
+        }
+
+        // TODO: this is not fully accurate
+        if (probe != 0) {
+            return true;
+        }
+
+        // move data from snd_queue to snd_buf
+        if (sndQueue.size() > 0) {
+            // no cwnd yet should run flush
+            if(cwnd == 0) {
+                return true;
+            }
+
+            // calculate window size
+            int cwnd0 = Math.min(sndWnd, rmtWnd);
+            if (!nocwnd) {
+                cwnd0 = Math.min(this.cwnd, cwnd0);
+            }
+
+            if(itimediff(sndNxt, sndUna + cwnd0) < 0) {
+                return true;
+            }
+        }
+
+        if (sndBuf.size() > 0) {
+            long current = this.current;
+
+            // calculate resent
+            int resent = fastresend > 0 ? fastresend : Integer.MAX_VALUE;
+            int rtomin = nodelay ? 0 : (rxRto >> 3);
+
+            // flush data segments
+            int change = 0;
+            boolean lost = false;
+            for (Iterator<Segment> itr = sndBufItr.rewind(); itr.hasNext(); ) {
+                Segment segment = itr.next();
+                if (segment.xmit == 0) {
+                    return true;
+                } else if (itimediff(current, segment.resendts) >= 0) {
+                    return true;
+                } else if (segment.fastack >= resent) {
+                    if (segment.xmit <= fastlimit || fastlimit <= 0) {
+                        return true;
+                    }
+                }
+            }
+        }
+
         return false;
     }
 


### PR DESCRIPTION
Currently every call to [update](https://github.com/szhnet/kcp-netty/blob/master/kcp-netty/src/main/java/io/jpower/kcp/netty/Kcp.java#L1331-L1363) calls flush which creates a new flush buffer and segment. Even when there is no work required to be done.

ByteBufAllocator.ioBuffer is a fairly expensive call to call every update.

Unless I am doing something wrong, Kcp#check [will schedule a work duration](https://github.com/szhnet/kcp-netty/blob/master/kcp-netty/src/main/java/io/jpower/kcp/netty/Kcp.java#L1407-L1412) (100ms by default) not necessarily when the next "action" is required. This might be better handled by changing Kcp#check?